### PR TITLE
fix: fix wrong user address in swap instruction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ fn _parse_swap_instruction(
     context: &TransactionContext,
 ) -> Result<SwapEvent, String> {
     let amm = bs58::encode(context.get_account_from_index(instruction.accounts[1] as usize)).into_string();
-    let user = bs58::encode(context.get_account_from_index(*instruction.accounts.last().unwrap() as usize)).into_string();
+    let user = bs58::encode(context.get_account_from_index(0)).into_string();
 
     let instructions_len = instruction.inner_instructions.len();
     let transfer_in = spl_token_substream::parse_transfer_instruction(&instruction.inner_instructions[instructions_len - 2], context)?;


### PR DESCRIPTION
Heyy guy I appreciate your great work! 
However, there might be an issue with how the swap event is parsed.

The user from the accounts of the instruction (means last index in context.accounts) does not guarantee a signature signer.

Let's check signituare: 4P9cV3ybDvjPGX9qe8p4otd9WEu35mqgn2jv9KkfHDmLWZGWpc4YhNt4zCAzxQYY6z2Qs5gyz1tk21baPJkeqZaa